### PR TITLE
Allow customizing the stringWidth implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 'use strict';
 const stringWidth = require('string-width');
 
-module.exports = function (str) {
-	return Math.max.apply(null, str.split('\n').map(stringWidth));
+module.exports = function (str, options) {
+	options = options || {};
+	options.getStringWidth = options.getStringWidth || stringWidth;
+
+	return Math.max.apply(null, str.split('\n').map(options.getStringWidth));
 };

--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 'use strict';
-var stringWidth = require('string-width');
+const stringWidth = require('string-width');
 
 module.exports = function (str) {
-	return Math.max.apply(null, str.split('\n').map(function (x) {
-		return stringWidth(x);
-	}));
+	return Math.max.apply(null, str.split('\n').map(stringWidth));
 };
-

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # widest-line [![Build Status](https://travis-ci.org/sindresorhus/widest-line.svg?branch=master)](https://travis-ci.org/sindresorhus/widest-line)
 
-> Get the visual width of the widest line in a string - the number of columns required to display it
+> Get the **visual** width of the widest line in a string - the number of columns required to display it, for ex. in a terminal
 
 Some Unicode characters are [fullwidth](https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms) and use double the normal width. [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code) are stripped and doesn't affect the width.
 

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,21 @@ widestLine('古\n\u001b[1m@\u001b[22m');
 ```
 
 
+## Advanced usage
+
+Getting the visual width of a string is non-trivial when Unicode is used.
+Furthermore, some terminals behave differently, for ex. iterm2 display some "big" emojis on 2 columns instead of one.
+
+To allow handling those special cases, the "string-width" algorithm may be customized:
+
+```js
+widestLine('🌒🌓🌔🌕🌖🌗🌘\nfull moon', {
+    getStringWidth: s => superStringWidth(s, {target: 'iterm2'}) // imaginary example
+});
+//=> 14
+```
+
+
 ## Related
 
 - [string-width](https://github.com/sindresorhus/string-width) - Get the visual width of a string

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,9 @@
 
 > Get the **visual** width of the widest line in a string - the number of columns required to display it, for ex. in a terminal
 
-Some Unicode characters are [fullwidth](https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms) and use double the normal width. [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code) are stripped and doesn't affect the width.
-
-Useful to be able to know the maximum width a string will take up in the terminal.
+* [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code) will be ignored and won't affect the width.
+* Unicode characters magic (ex. some are [fullwidth](https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms)
+and use double the normal width) will be handled on a "best effort" basis.
 
 
 ## Install

--- a/test.js
+++ b/test.js
@@ -1,8 +1,19 @@
 import test from 'ava';
 import fn from './';
 
-test(t => {
+test('main', t => {
 	t.is(fn('a'), 1);
 	t.is(fn('a\nbe'), 2);
 	t.is(fn('古\n\u001b[1m@\u001b[22m'), 2);
+});
+
+test('using custom string-width', t => {
+	function getStringWidth(s) {
+		// Dumb, just for tests
+		return s.length * 2;
+	}
+
+	t.is(fn('a', {getStringWidth}), 2);
+	t.is(fn('a\nbe', {getStringWidth}), 4);
+	t.is(fn('古\n\u001b[1m@\u001b[22m', {getStringWidth}), 20);
 });


### PR DESCRIPTION
In order to fix https://github.com/sindresorhus/boxen/issues/24

The simplest, least intrusive way is to allow customizing the stringWidth implementation, for ex. still using npm/string-width, but with special parameters (see https://github.com/sindresorhus/string-width/pull/14)

Another PR will add the same feature to boxen.