### PR TITLE
ES2015ify and require Node.js 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - 'stable'
-  - '0.12'
-  - '0.10'
+  - '8'
+  - '6'
+  - '4'

--- a/index.js
+++ b/index.js
@@ -1,9 +1,5 @@
 'use strict';
-var stringWidth = require('string-width');
+const stringWidth = require('string-width');
 
-module.exports = function (str) {
-	return Math.max.apply(null, str.split('\n').map(function (x) {
-		return stringWidth(x);
-	}));
-};
+module.exports = str => Math.max.apply(null, str.split('\n').map(x => stringWidth(x)));
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && ava"
@@ -45,7 +45,7 @@
     "fixed-width"
   ],
   "dependencies": {
-    "string-width": "^1.0.1"
+    "string-width": "^2.1.1"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
I had considered using spread parameters but they are not available in Node.js 4.

The goal is to get boxen to stop installing two versions of string-width.  boxen already requires node >= 4 so updating to widest-line 2.x will be a non-breaking change.  I can submit a PR to boxen if you like.

If you want me to update the package.json version I can do that, but looking at your other commit logs it looks like you always do that in a separate commit.