### PR TITLE
Fix potential stack overflow

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 'use strict';
 const stringWidth = require('string-width');
 
-module.exports = input => Math.max.apply(null, input.split('\n').map(x => stringWidth(x)));
-
+module.exports = input => {
+	let max = 0;
+	for (const s of input.split('\n')) max = Math.max(max, stringWidth(s));
+	return max;
+};


### PR DESCRIPTION
v8 throws a "maximum call stack size exceeded" error for more than ~125,000 args passed via `fn.apply`.

This is also slightly (~15%) faster.

(Don't mean to be pedantic. I know this is unlikely to get hit.)